### PR TITLE
Fix GUI matrix stack leak when hotbar render is cancelled

### DIFF
--- a/src/main/java/me/zipestudio/hudless/backend/HudAnimationHandler.java
+++ b/src/main/java/me/zipestudio/hudless/backend/HudAnimationHandler.java
@@ -122,6 +122,7 @@ public class HudAnimationHandler {
                 if (ci != null) {
                     ci.cancel();
                 }
+                matrices.popMatrix();
                 return;
             }
         }
@@ -163,6 +164,7 @@ public class HudAnimationHandler {
                 if (ci != null) {
                     ci.cancel();
                 }
+                matrices.popPose();
                 return;
             }
         }


### PR DESCRIPTION
## Summary

Fixes a GUI matrix stack leak when Hudless cancels hotbar rendering.

In the newer rendering branches, Hudless pushes the GUI matrix before rendering animated HUD elements. When the hotbar render path is cancelled, the method returned before restoring the matrix stack. This can leave a translation active for later GUI rendering.

The issue is visible when another mod wraps hotbar rendering with its own matrix transform. In my test case, Controllable's "Console Hotbar" option shifted the hotbar upward, then Hudless cancelled the hotbar render without popping its own matrix. After that, later menus/screens could appear shifted upward.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/723beb1b-61f5-4599-99d1-6c405f3507da" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/06c93635-633b-44fe-8337-b7e936d74f53" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3182bf81-8ef6-471c-8ad9-88185bcf4a26" />

This patch restores the matrix stack before returning from cancelled hotbar renders in the affected code paths.

## Changes

* Pop `Matrix3x2fStack` before returning from the cancelled hotbar render path on newer Minecraft versions.
* Pop `PoseStack` before returning from the cancelled hotbar render path on the intermediate rendering branch.
* Leaves the legacy branch unchanged, since it already restored the pose stack before returning.

## Testing

Tested locally on:

* Minecraft 1.21.8
* Fabric
* Hudless 2.0.5 patched
* Controllable 0.25.3

Manual test:

1. Enabled Controllable's "Console Hotbar" option.
2. Enabled Hudless hotbar hiding.
3. Joined a world and waited for the hotbar to hide.
4. Opened inventory, pause menu, options, video settings, and chat.
5. Repeated the test with Controllable's "Console Hotbar" option disabled.

Result:

* No menu/screen upward shift observed.
* Hotbar hiding still works normally.
* No new visual regression found during testing.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/afdbec6a-aa42-4d0b-af26-11f2d4b6cec0" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8888b0fd-e379-4ab1-a721-aa21de5b816e" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/653ebaf1-20a7-42ca-ae68-174554c97b85" />

Build:

```text
./gradlew.bat clean buildAndCollect+fabric+All -Pci_loader=fabric
BUILD SUCCESSFUL
```
